### PR TITLE
fix: do not remove dev dependencies before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ jobs:
 
     - stage: deploy-dev
       script:
-        - yarn --production
         - yarn sls deploy -s dev -v && yarn sls -s dev files
 
     - stage: release
@@ -39,5 +38,4 @@ jobs:
 
     - stage: deploy-prod
       script:
-        - yarn --production
         - yarn sls deploy -s production -v && yarn sls -s production files

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier": "^1.13.7",
     "semantic-release": "^15.9.3",
     "semantic-release-conventional-commits": "^2.0.1",
-    "serverless": "^1.28.0",
+    "serverless": "^1.29.2",
     "serverless-offline": "^3.23.1"
   },
   "keywords": [],

--- a/serverless.yml
+++ b/serverless.yml
@@ -136,7 +136,6 @@ resources:
           WriteCapacityUnits: 1
 
 package:
-  excludeDevDependencies: false
   exclude:
     - '.*'
     - '**/*.swp'
@@ -144,5 +143,3 @@ package:
     - '__coverage__/**'
     - 'yarn.lock'
     - 'README.md'
-    - 'node_modules/serverless/**'
-    - 'node_modules/serverless-*/**'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6756,7 +6756,7 @@ serverless-offline@^3.23.1:
     uuid "^3.2.1"
     velocityjs "^0.9.3"
 
-serverless@^1.28.0:
+serverless@^1.29.2:
   version "1.29.2"
   resolved "https://registry.yarnpkg.com/serverless/-/serverless-1.29.2.tgz#6dbc6d471bddb300b63c193d7f27a2a331af4445"
   dependencies:


### PR DESCRIPTION
We are relying on serverless to remove dev dependencies when packaging
for deployment.